### PR TITLE
fix: /login 페이지 Suspense 경계 적용 (force-dynamic 제거)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,7 @@
 'use client'
 // src/app/login/page.tsx
-export const dynamic = 'force-dynamic';
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import Image from 'next/image'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -29,7 +28,7 @@ const SLIDES = [
   }
 ]
 
-export default function LoginPage() {
+function LoginContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [loading, setLoading] = useState(false)
@@ -187,5 +186,19 @@ export default function LoginPage() {
         )}
       </AnimatePresence>
     </main>
+  )
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-dvh items-center justify-center bg-[#F5F8FF]">
+          <div className="w-10 h-10 rounded-full border-3 border-[#4A90D9] border-t-transparent animate-spin" />
+        </div>
+      }
+    >
+      <LoginContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
- `/login` 페이지의 `useSearchParams()` 호출을 `<Suspense>` 경계로 감싸 prerender 에러를 정석으로 해결합니다.
- 기존 임시 우회였던 `export const dynamic = 'force-dynamic'`를 제거합니다.
- 이미 같은 패턴이 적용된 `/login-success`, `/child`, `/child-edit`와 일관된 형태로 통일했습니다.

## Why
빌드 로그(`Error occurred prerendering page \"/login\"`)에서 다음 에러가 발생했습니다:
> useSearchParams() should be wrapped in a suspense boundary at page \"/login\"

`force-dynamic`으로 회피할 수도 있지만, 다른 페이지들은 모두 Suspense 패턴을 쓰고 있어 코드 일관성을 위해 동일하게 맞췄습니다.

## Test plan
- [ ] Vercel 빌드 통과 확인
- [ ] 프로덕션 `/login` 직접 접근 시 정상 동작 (온보딩 슬라이드 → Google 로그인 버튼)
- [ ] 백엔드 OAuth 콜백으로 `/login?token=...` 또는 `/login?jwt=...` 진입 시 `/chat`으로 리다이렉트
- [ ] 이미 로그인된 상태로 `/login` 진입 시 `/chat`으로 자동 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)