### PR TITLE
fix: 기존 상담 진입 시 첫째 아이로 잘못 동작하는 버그 수정

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -27,6 +27,7 @@ export default function ChatPage() {
     messages, consultationId,
     isLoading, addMessage, updateLastMessage, setConsultationId,
     setLoading, addChatSession, updateChatSession, setMessages, setHistoryLoaded,
+    chatSessions,
   } = useAppStore()
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const [uploadedImg, setUploadedImg] = useState<string | null>(null)
@@ -267,9 +268,18 @@ export default function ChatPage() {
   const resolveChildForSession = useCallback((): ChildResponse | null => {
     if (activeChild) return activeChild
     if (allChildren.length === 1) return allChildren[0]
-    if (consultationId && allChildren.length > 0) return allChildren[0]
     return null
-  }, [activeChild, allChildren, consultationId])
+  }, [activeChild, allChildren])
+
+  // 기존 상담에 진입한 경우, chatSessions에서 매칭되는 세션의 childId로
+  // activeChild를 자동 동기화한다. 이를 누락하면 첫째 아이로 잘못 fallback 된다.
+  useEffect(() => {
+    if (!consultationId || activeChild || allChildren.length === 0) return
+    const session = chatSessions.find((s) => s.id === Number(consultationId))
+    if (!session) return
+    const matched = allChildren.find((c) => String(c.id) === session.childId)
+    if (matched) setActiveChild(matched)
+  }, [consultationId, activeChild, allChildren, chatSessions])
 
   const openChildModal = useCallback((action: PendingAction) => {
     if (allChildren.length === 0) {


### PR DESCRIPTION
## Summary
- 기존 상담을 다시 열었을 때 항상 \`allChildren[0]\` (첫째 아이) 로 동작하던 문제를 수정합니다.
- \`consultationId\` 가 존재하면 \`chatSessions\` 에 저장된 해당 세션의 \`childId\` 로 \`activeChild\` 를 자동 동기화합니다.

## Why
\`src/app/chat/page.tsx:267-272\` 의 \`resolveChildForSession\` 에 다음과 같은 fallback 이 있었습니다:

\`\`\`ts
if (consultationId && allChildren.length > 0) return allChildren[0]
\`\`\`

이 분기는 \"기존 채팅방이면 아이 선택 모달을 띄우지 말자\" 는 의도였으나, 해당 채팅방의 실제 \`childId\` 를 조회하지 않고 무조건 첫째 아이로 처리하는 버그였습니다.

### 재현 시나리오
1. 아이 2명 이상 등록 (예: 큰애 / 작은애)
2. **작은애** 를 골라 상담을 1회 진행 (정상)
3. 상담 종료 후 상담 목록에서 **그 작은애의 상담을 다시 클릭**
4. 메시지 전송 또는 음성 모드 진입
5. 실제로는 \"큰애의 상담\" 으로 전송/분석됨 ❌

## 수정 내용
- \`resolveChildForSession\` 의 잘못된 fallback 분기 제거 → 다중 아이 상태에서 \`activeChild\` 가 없으면 모달이 뜨도록 정상화.
- \`consultationId\` 가 있고 \`activeChild\` 가 비어 있을 때, store 의 \`chatSessions\` 에서 매칭되는 세션을 찾아 \`childId\` 로 \`activeChild\` 를 자동 설정하는 \`useEffect\` 추가.

## Test plan
- [ ] 아이 2명 이상 등록 → **둘째** 아이로 상담 1회 진행 → 종료 후 상담 목록에서 그 상담 재진입 → 메시지 보내기 시 둘째 아이로 동작
- [ ] 둘째 아이 상담을 재진입 후 \"활성 아이 칩(activeChild pill)\" UI 가 둘째 아이로 표시되는지 확인
- [ ] 아이 1명만 있을 때 정상 동작 (회귀 없음)
- [ ] 새 상담 시작 시 다중 아이라면 아이 선택 모달이 정상적으로 뜨는지

## Note
직접 URL 진입 (예: 푸시 알람 클릭으로 바로 /chat 진입, chatSessions 가 아직 로드되지 않은 상태) 시 fallback 매칭이 안 될 수 있습니다. 이 경우엔 다중 아이라면 모달이 뜨는 안전한 동작이지만, BE 에서 \`GET /api/chats/{chatId}\` 같은 단일 chat 조회 API 를 만들어 childId 를 직접 받는 후속 작업을 권장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)